### PR TITLE
Fix deprecation warning (include is deprecated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Removed
 ### Fixed
+- *[#2](https://github.com/idealista/nextcloud_role/issues/8) Fix deprecation warnings* @Pablohn26
 
 ## [2.0.0](https://github.com/idealista/nextcloud_role/tree/2.0.0)
  ### [Full Changelog](https://github.com/idealista/nextcloud_role/compare/1.0.1...2.0.0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: NEXTCLOUD | Install
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - nextcloud_install
 
 - name: NEXTCLOUD | Configure
-  include: config.yml
+  include_tasks: config.yml
   tags:
     - nextcloud_configure


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fix deprecation warning using include_tasks instead of include using ansible-core 2.12

### Benefits

<!-- What benefits will be realized by the code change? -->

All deprecation warnings removed up to [ansible-core 2.12](https://github.com/ansible/ansible/blob/v2.12.0/changelogs/CHANGELOG-v2.12.rst)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Using include_tasks, but import_tasks could be used too. More info [here](https://github.com/idealista/postgresql_role/issues/15).

### Applicable Issues

<!-- Enter any applicable Issues here -->
#7 